### PR TITLE
Add nil completion blocks

### DIFF
--- a/JSQMessagesViewController/Categories/JSQSystemSoundPlayer+JSQMessages.m
+++ b/JSQMessagesViewController/Categories/JSQSystemSoundPlayer+JSQMessages.m
@@ -62,10 +62,10 @@ static NSString * const kJSQMessageSentSoundName = @"message_sent";
     NSString *fileName = [NSString stringWithFormat:@"JSQMessagesAssets.bundle/Sounds/%@", soundName];
     
     if (asAlert) {
-        [[JSQSystemSoundPlayer sharedPlayer] playAlertSoundWithFilename:fileName fileExtension:kJSQSystemSoundTypeAIFF];
+        [[JSQSystemSoundPlayer sharedPlayer] playAlertSoundWithFilename:fileName fileExtension:kJSQSystemSoundTypeAIFF completion:nil];
     }
     else {
-        [[JSQSystemSoundPlayer sharedPlayer] playSoundWithFilename:fileName fileExtension:kJSQSystemSoundTypeAIFF];
+        [[JSQSystemSoundPlayer sharedPlayer] playSoundWithFilename:fileName fileExtension:kJSQSystemSoundTypeAIFF completion:nil];
     }
     
     //  restore original bundle


### PR DESCRIPTION
The JSQSystemSoundPlayer CocoaPods dependency is behind the JSQSystemSoundPlayer
master branch. This switches to use the master branch.